### PR TITLE
NLogPerformance - MultiFile splits the workload on multiple targets

### DIFF
--- a/NLogPerformance/nlog.config
+++ b/NLogPerformance/nlog.config
@@ -21,10 +21,43 @@
       <target name="AsyncFileSimple" type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="1000" timeToSleepBetweenBatches="0">
         <target name="SyncFileSimple" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
       </target>
+      <target name="MultiFile" type="RoundRobinGroup">
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti0.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti1.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti2.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti3.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti4.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti5.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti6.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti7.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti8.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+        <target type="AsyncWrapper" overflowAction="Block" queueLimit="10000" batchSize="100" timeToSleepBetweenBatches="0">
+          <target type="File" fileName="C:\Temp\Log\NLogPerformanceMulti9.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+        </target>
+      </target>
     </targets>
 
     <rules>
       <logger name="Logger*" minlevel="Trace" writeTo="AsyncFile" />
+      <logger name="MultiLogger*" minlevel="Trace" writeTo="MultiFile" />
       <logger name="SyncLogger*" minlevel="Trace" writeTo="SyncFile" />
       <logger name="PerfLogger*" minlevel="Trace" writeTo="AsyncFilePerf" />
       <logger name="PerfSyncLogger*" minlevel="Trace" writeTo="SyncFilePerf" />

--- a/run-nlogperformance-tests.bat
+++ b/run-nlogperformance-tests.bat
@@ -10,6 +10,8 @@ NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 4  16 1 >> perfor
 NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 8  16 1 >> performance-log.log
 REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 16 16 1 >> performance-log.log
 REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 60 16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe MultiLogger 10000000 1  16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe MultiLogger 10000000 1  128 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 1  8  1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 1  128 1 >> performance-log.log


### PR DESCRIPTION
Artificial delay is introduced by the Logger-thead doing the precalculation, so the 10 async-targets should keep up, even though their BatchSize has been reduced.