### PR TITLE
Feature/simplify onboarding

### DIFF
--- a/ManyThreadsTester/ManyThreadsTester/nlog.config
+++ b/ManyThreadsTester/ManyThreadsTester/nlog.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <nlog autoReload="true" xmlns="http://www.nlog-project.org/schemas/NLog.xsd">
-  <variable name="logDirectory" value="C:/temp/manythreadsTest/" />
+  <variable name="logDirectory" value="%temp%/NLogPerformance//manythreadsTest/" />
   <targets>
     <target name="file" type="File" fileName="${basedir}//${machinename}_TaskService ${shortdate}.log" layout="${longdate}|${level}|[${threadid}]||${message} ${exception:format=tostring}" keepFileOpen="true" concurrentWrites="false" />
     <!--  async="true"

--- a/NLogPerformance/NLogPerformance.csproj
+++ b/NLogPerformance/NLogPerformance.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tester1/App.config
+++ b/Tester1/App.config
@@ -1,6 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
 </configuration>

--- a/Tester1/Program.cs
+++ b/Tester1/Program.cs
@@ -30,8 +30,8 @@ namespace PerformanceTest
             Console.WriteLine("start test with {0:N0} messages", count);
 
             Stopwatch sw = Stopwatch.StartNew();
-            var paralllel = 1;
-            for (var i = 0; i < paralllel; i++)
+            var parallel = 1;
+            for (var i = 0; i < parallel; i++)
             {
                 WriteMessages(logger, count);
             }
@@ -39,7 +39,7 @@ namespace PerformanceTest
 
             Console.WriteLine("{2:N} messages. Time taken: {0:N}ms. {1:N} / sec", sw.Elapsed.TotalMilliseconds,
                 ((double)count / sw.Elapsed.TotalMilliseconds) * 1000, count);
-            if (args == null || args.Length == 0)
+            if (args.Length == 0)
             {
                 Console.ReadKey();
             }

--- a/Tester1/Tester1.csproj
+++ b/Tester1/Tester1.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tester1/nlog.config
+++ b/Tester1/nlog.config
@@ -11,12 +11,12 @@
       <add assembly ="NLogTest"/>
     </extensions>-->
     <!--<targets async="true" >
-      <target name ="mipLoggertarget" xsi:type="File" fileName="c:/temp/Log/${gdc:item=jobId}/MIP/MipLogger.log" layout="${message}" keepFileOpen="true" />
+      <target name ="mipLoggertarget" xsi:type="File" fileName="%temp%/NLogPerformance//Log/${gdc:item=jobId}/MIP/MipLogger.log" layout="${message}" keepFileOpen="true" />
     </targets>-->
     <!--<targets>
 
       <target name="asyncWrapper" xsi:type="AsyncWrapper">
-        <target name ="mipLoggertarget" xsi:type="File" fileName="c:/temp/Log/${gdc:item=jobId}/MIP/MipLogger.log" layout="${message}" keepFileOpen="true" />
+        <target name ="mipLoggertarget" xsi:type="File" fileName="%temp%/NLogPerformance//Log/${gdc:item=jobId}/MIP/MipLogger.log" layout="${message}" keepFileOpen="true" />
       </target>
 
 
@@ -25,14 +25,14 @@
     <!--<targets  >
 
       <target name="asyncWrapper" xsi:type="AsyncWrapper"   overflowAction="Discard">
-        <target name ="mipLoggertarget" xsi:type="File" fileName="c:/temp/Log/${gdc:item=jobId}.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
+        <target name ="mipLoggertarget" xsi:type="File" fileName="%temp%/NLogPerformance//Log/${gdc:item=jobId}.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
       </target>
 
     </targets>-->
     <!--<targets  >
 
       <target name="asyncWrapper" xsi:type="AsyncWrapper"   >
-        <target name ="mipLoggertarget" xsi:type="File" fileName="c:/temp/Log/test4.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
+        <target name ="mipLoggertarget" xsi:type="File" fileName="%temp%/NLogPerformance//Log/test4.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
       </target>
 
     </targets>-->
@@ -43,7 +43,7 @@
     <targets  async="true" >
 
      
-        <target name ="mipLoggertarget" xsi:type="File" fileName="c:/temp/Log/test5.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
+        <target name ="mipLoggertarget" xsi:type="File" fileName="%temp%/NLogPerformance//Log/test5.log" layout="${message}" keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" />
     
     </targets>-->
 
@@ -57,25 +57,25 @@
       
       <!--<target name="asyncWrapper" xsi:type="AsyncWrapper" overflowAction="Block" queueLimit="1000000" batchSize="1000" timeToSleepBetweenBatches="0"   >
         <target name ="mipLoggertargetwrapped" xsi:type="File"
-            fileName="c:/temp/Log/test1.log"
+            fileName="%temp%/NLogPerformance//Log/test1.log"
             layout="${message}" keepFileOpen="true" AutoFlush="false"
             ConcurrentWrites="true"
             CleanupFileName="false"/>
       </target>
       <target name="asyncWrapper2" xsi:type="AsyncWrapper" overflowAction="Block" queueLimit="1000000" batchSize="1000" timeToSleepBetweenBatches="0"   >
         <target name ="mipLoggertargetwrapped2" xsi:type="File"
-            fileName="c:/temp/Log/test1.log"
+            fileName="%temp%/NLogPerformance//Log/test1.log"
             layout="${message}" keepFileOpen="true" AutoFlush="false"
             ConcurrentWrites="false"
             CleanupFileName="false"/>
       </target>
       <target name ="mipLoggertarget" xsi:type="File"
-            fileName="c:/temp/Log/test1.log"
+            fileName="%temp%/NLogPerformance//Log/test1.log"
             layout="${message}" keepFileOpen="true" AutoFlush="false"
             ConcurrentWrites="true"
             CleanupFileName="false"/>-->
       <target name ="mipLoggertarget2" xsi:type="File"
-              fileName="c:/temp/Log/test1.log"
+              fileName="%temp%/NLogPerformance//Log/test1.log"
               layout="${message}" keepFileOpen="true" AutoFlush="false"
               ConcurrentWrites="false"
               CleanupFileName="false"/>
@@ -84,7 +84,7 @@
       <!--<target name="mipLoggertargetAsync" xsi:type="AsyncWrapper" overflowAction="Block" queueLimit="40000" batchSize="20000" 
               timeToSleepBetweenBatches="0">
               <target name ="mipLoggertargetWrapped" xsi:type="File"
-                fileName="c:/temp/Log/test1.log"
+                fileName="%temp%/NLogPerformance//Log/test1.log"
                 layout="${message}"
                 keepFileOpen="true" AutoFlush="false" ConcurrentWrites="false" CleanupFileName="false" />
       </target>
@@ -93,11 +93,7 @@
     </targets>
     <rules>
       <logger name="*" minlevel="Trace" writeTo="mipLoggertarget2"/>
-
     </rules>
   </nlog>
 
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-  </startup>
 </configuration>


### PR DESCRIPTION
I changed a little performance tests:
1. Use system temp folder instead of hardcoded C:\temp
2. Avoid running x32 processes on x64 OS (my opinion - when you use x32 code you don't think about performance)
3. Update NLog submodule to the latest version (current solution is failed, because of zero async wait time)