### PR TITLE
NLogPerformance - Added message arguments option

### DIFF
--- a/NLogPerformance/nlog.config
+++ b/NLogPerformance/nlog.config
@@ -9,9 +9,9 @@
         internalLogFile="C:\Temp\Log\NLogPerformance_Internal.txt" internalLogLevel="Off" throwExceptions="true"
         >
     <targets>
-      <target name="NullWithoutFormat" type="Null" formatMessage="false" />
-      <target name="NullWithSimpleFormat" type="Null" formatMessage="true" layout="${message}${exception:format=tostring}" />
-      <target name="NullWithFullFormat" type="Null" formatMessage="true" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      <target name="NullWithoutFormat" type="Null" formatMessage="false" OptimizeBufferReuse="true" />
+      <target name="NullWithSimpleFormat" type="Null" formatMessage="true" layout="${message}${exception:format=tostring}" OptimizeBufferReuse="true" />
+      <target name="NullWithFullFormat" type="Null" formatMessage="true" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" OptimizeBufferReuse="true" />
       <target name="AsyncFile" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
         <target name="SyncFile" type="File" fileName="C:\Temp\Log\NLogPerformance-${date:universalTime=true:format=yyyy}.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} [${threadid}] ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
       </target>
@@ -23,6 +23,24 @@
       </target>
       <target name="AsyncFileSimple" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
         <target name="SyncFileSimple" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-${date:universalTime=true:format=yyyy}.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelTrace" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleTrace" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Trace.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelDebug" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleDebug" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Debug.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelInfo" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleInfo" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Info.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelWarn" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleWarn" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Warn.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelError" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleError" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Error.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
+      </target>
+      <target name="AsyncFileLevelFatal" type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
+        <target name="SyncFileSimpleFatal" type="File" fileName="C:\Temp\Log\NLogPerformanceSimple-Fatal.txt" autoFlush="false" keepFileOpen="true" concurrentWrites="false" layout="${longdate} ${level:uppercase=true} ${logger} - ${message}${exception:format=tostring}" />
       </target>
       <target name="MultiFile" type="RoundRobinGroup">
         <target type="AsyncWrapper" overflowAction="Block" timeToSleepBetweenBatches="0">
@@ -59,6 +77,7 @@
     </targets>
 
     <rules>
+      <logger name="NullLogger*" minLevel="Trace" writeTo="NullWithoutFormat" />
       <logger name="Logger*" minlevel="Trace" writeTo="AsyncFile" />
       <logger name="MultiLogger*" minlevel="Trace" writeTo="MultiFile" />
       <logger name="SyncLogger*" minlevel="Trace" writeTo="SyncFile" />
@@ -66,6 +85,12 @@
       <logger name="PerfSyncLogger*" minlevel="Trace" writeTo="SyncFilePerf" />
       <logger name="PerfArchiveLogger*" minlevel="Trace" writeTo="SyncFilePerfArchive" />
       <logger name="SimpleLogger*" minlevel="Trace" writeTo="AsyncFileSimple" />
+      <logger name="SimpleLevel*" level="Trace" writeTo="AsyncFileLevelTrace" />
+      <logger name="SimpleLevel*" level="Debug" writeTo="AsyncFileLevelDebug" />
+      <logger name="SimpleLevel*" level="Info" writeTo="AsyncFileLevelInfo" />
+      <logger name="SimpleLevel*" level="Warn" writeTo="AsyncFileLevelWarn" />
+      <logger name="SimpleLevel*" level="Error" writeTo="AsyncFileLevelError" />
+      <logger name="SimpleLevel*" level="Fatal" writeTo="AsyncFileLevelFatal" />
       <logger name="SimpleSyncLogger*" minlevel="Trace" writeTo="SyncFileSimple" />
     </rules>
   </nlog>

--- a/run-nlogperformance-tests.bat
+++ b/run-nlogperformance-tests.bat
@@ -5,24 +5,29 @@ NLogPerformance\bin\Release\NLogPerformance.exe PerfSyncLogger 10000000 1  128 1
 NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 1  128 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 2  16 1 >> performance-log.log
-NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 4  16 1 >> performance-log.log
-NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 8  16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 16 16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 3000000 60 16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 4  16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 8  16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 16 16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe Logger 10000000 60 16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe PerfArchiveLogger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe MultiLogger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe MultiLogger 10000000 1  128 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 1  128 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 3000000 2  16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 3000000 4  16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 3000000 8  16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 3000000 16 16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 3000000 60 16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 10000000 2  16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 15000000 4  16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 15000000 8  16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 15000000 16 16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SyncLogger 15000000 60 16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 1  16 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 1  128 1 >> performance-log.log
 NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 2  16 1 >> performance-log.log
-NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 3000000 4  16 1 >> performance-log.log
-NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 3000000 8  16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 3000000 16 16 1 >> performance-log.log
-REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 3000000 60 16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 4  16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 8  16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 16 16 1 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLogger 10000000 60 16 1 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe SimpleLevel 20000000 1 128 1 2 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe SimpleLevel 20000000 4 128 1 2 >> performance-log.log
+NLogPerformance\bin\Release\NLogPerformance.exe SimpleLevel 20000000 8 128 1 2 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLevel 20000000 16 128 1 2 >> performance-log.log
+REM NLogPerformance\bin\Release\NLogPerformance.exe SimpleLevel 20000000 60 128 1 2 >> performance-log.log


### PR DESCRIPTION
Also fixed a bug, where it failed to divide the message-count properly according to the thread-count (All tests before this commit actually need to multiply the msgs/sec-result with the thread-count).