### PR TITLE
Compare console

### DIFF
--- a/CompareConsole.sln
+++ b/CompareConsole.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2026
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompareConsole", "CompareConsole\CompareConsole.csproj", "{4FE61E40-3C2B-4B3E-B4F7-C798FE3D250C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4FE61E40-3C2B-4B3E-B4F7-C798FE3D250C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FE61E40-3C2B-4B3E-B4F7-C798FE3D250C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FE61E40-3C2B-4B3E-B4F7-C798FE3D250C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FE61E40-3C2B-4B3E-B4F7-C798FE3D250C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {675C42CC-5DB1-4BF3-A4AC-D9B3F9CCAA1F}
+	EndGlobalSection
+EndGlobal

--- a/CompareConsole/CompareConsole.csproj
+++ b/CompareConsole/CompareConsole.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.6" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/CompareConsole/Program.cs
+++ b/CompareConsole/Program.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Diagnostics;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using NLog.Targets.Wrappers;
+using Serilog;
+using Serilog.Events;
+
+namespace PerformanceTest
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("starting");
+            var count = 1_000_000;
+            StartNLog(count);
+            StartSerilog(count);
+            StartNLog(count);
+            StartSerilog(count);
+            Console.WriteLine("Press any key");
+            Console.ReadLine();
+        }
+
+        private static void StartSerilog(int count)
+        {
+            var fileName = $"serilog-{DateTime.Now.Ticks}.log";
+            var log = new LoggerConfiguration()
+                .WriteTo.File(fileName, buffered: true, shared: false,
+                    flushToDiskInterval: TimeSpan.FromMilliseconds(1000))
+                .CreateLogger();
+
+            Log.Logger = log;
+
+            Console.WriteLine("start Serilog");
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < count; i++)
+            {
+              //  log.Write(LogEventLevel.Information, "message {0}", i);
+                log.Write(LogEventLevel.Information, "message {A}", i);
+            }
+
+            stopwatch.Stop();
+
+            Console.WriteLine("Serilog done. {0} sec, {1:N0} item/sec", stopwatch.Elapsed.TotalSeconds, count / stopwatch.Elapsed.TotalSeconds);
+        }
+
+        private static void StartNLog(int count)
+        {
+            var fileName = $"nlog-{DateTime.Now.Ticks}.log";
+            var config = new LoggingConfiguration();
+            var fileTarget = new FileTarget("file1")
+            {
+                FileName = fileName,
+                KeepFileOpen = true, //400 -> 650K/s
+                Layout = "${longdate} [${level}] ${message}",
+                CleanupFileName = false,
+            };
+            var target = new BufferingTargetWrapper(fileTarget)
+            {
+                BufferSize = 1000,
+                SlidingTimeout = false,
+                FlushTimeout = 1000,
+                Name = "BufferedTarget"
+
+            };
+
+            config.AddTarget("file", target);
+            config.AddRuleForAllLevels(target);
+            LogManager.Configuration = config;
+
+            Console.WriteLine("start NLog");
+
+            var logger = LogManager.GetLogger("logger1");
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < count; i++)
+            {
+               // logger.Info("message {0}", i);
+                logger.Info("message {A}", i);
+            }
+            LogManager.Flush(TimeSpan.FromMinutes(5));
+            stopwatch.Stop();
+
+            Console.WriteLine("NLog done. {0} sec, {1:N0} item/sec", stopwatch.Elapsed.TotalSeconds, count / stopwatch.Elapsed.TotalSeconds);
+        }
+    }
+}


### PR DESCRIPTION
@snakefoot 

was thinking about this: https://www.darylcumbo.net/serilog-vs-nlog-benchmarks/

I couldn't believe it. 

Got this:

![image](https://user-images.githubusercontent.com/5808377/41180768-9a80cd70-6b6f-11e8-9732-4c300c9f7613.png)

with file keep open:

![image](https://user-images.githubusercontent.com/5808377/41180590-f9f81d86-6b6e-11e8-9ff0-c9b4865bd7d5.png)

but OK, the default buffer of 100 items is an issue. 

Maybe something to benchmark this in the future? 
